### PR TITLE
Support commands in original body

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ class Command {
   }
 
   listener (context) {
-    const {comment, issue, pull_request} = context.payload
+    const {comment, issue, pull_request: pr} = context.payload
 
-    const command = (comment || issue || pull_request).body.match(this.matcher)
+    const command = (comment || issue || pr).body.match(this.matcher)
 
     if (command && this.name === command[1]) {
       return this.callback(context, {name: command[1], arguments: command[2]})

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ class Command {
   }
 
   listener (context) {
-    const command = context.payload.comment.body.match(this.matcher)
+    const {comment, issue, pull_request} = context.payload
+
+    const command = (comment || issue || pull_request).body.match(this.matcher)
 
     if (command && this.name === command[1]) {
       return this.callback(context, {name: command[1], arguments: command[2]})
@@ -30,7 +32,8 @@ class Command {
  */
 module.exports = (robot, name, callback) => {
   const command = new Command(name, callback)
-  robot.on('issue_comment.created', command.listener.bind(command))
+  const events = ['issue_comment.created', 'issues.opened', 'pull_request.opened']
+  robot.on(events, command.listener.bind(command))
 }
 
 module.exports.Command = Command

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/probot/commands",
   "devDependencies": {
     "jest": "^21.2.1",
+    "probot": "^6.2.0",
     "standard": "^10.0.2"
   },
   "standard": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,4 +92,30 @@ describe('commands', () => {
 
     expect(callback).not.toHaveBeenCalled()
   })
+
+  it('invokes command on issues.opened', async () => {
+    await robot.receive({
+      event: 'issues',
+      payload: {
+        action: 'opened',
+        issue: {body: '/foo bar'}
+      }
+    })
+
+    expect(callback).toHaveBeenCalled()
+    expect(callback.mock.calls[0][1]).toEqual({name: 'foo', arguments: 'bar'})
+  })
+
+  it('invokes command on pull_request.opened', async () => {
+    await robot.receive({
+      event: 'pull_request',
+      payload: {
+        action: 'opened',
+        issue: {body: '/foo bar'}
+      }
+    })
+
+    expect(callback).toHaveBeenCalled()
+    expect(callback.mock.calls[0][1]).toEqual({name: 'foo', arguments: 'bar'})
+  })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,54 +1,94 @@
-const {EventEmitter} = require('events')
+const {createRobot} = require('probot')
 const commands = require('..')
 
 describe('commands', () => {
   let callback
   let robot
 
-  function payload (text) {
-    return {payload: {comment: {body: text}}}
-  }
-
   beforeEach(() => {
     callback = jest.fn()
-    robot = new EventEmitter()
+    robot = createRobot({app: jest.fn().mockReturnValue('test')})
     commands(robot, 'foo', callback)
   })
 
-  it('invokes callback and passes command logic', () => {
-    robot.emit('issue_comment.created', payload('hello world\n\n/foo bar'))
+  it('invokes callback and passes command logic', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: {body: 'hello world\n\n/foo bar'}
+      }
+    })
 
     expect(callback).toHaveBeenCalled()
     expect(callback.mock.calls[0][1]).toEqual({name: 'foo', arguments: 'bar'})
   })
 
-  it('invokes the command without arguments', () => {
-    robot.emit('issue_comment.created', payload('hello world\n\n/foo'))
+  it('invokes the command without arguments', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: {body: 'hello world\n\n/foo'}
+      }
+    })
 
     expect(callback).toHaveBeenCalled()
     expect(callback.mock.calls[0][1]).toEqual({name: 'foo', arguments: undefined})
   })
 
-  it('does not call callback for other commands', () => {
-    robot.emit('issue_comment.created', payload('hello world\n\n/nope nothing to see'))
+  it('does not call callback for other commands', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: {body: 'hello world\n\n/nope nothing to see'}
+      }
+    })
+
     expect(callback).not.toHaveBeenCalled()
   })
 
-  it('does not call callback for superstring matches', () => {
-    robot.emit('issue_comment.created', payload('/foobar'))
+  it('does not call callback for superstring matches', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: {body: '/foobar'}
+      }
+    })
+
     expect(callback).not.toHaveBeenCalled()
   })
 
-  it('does not call callback for substring matches', () => {
-    robot.emit('issue_comment.created', payload('/fo'))
+  it('does not call callback for substring matches', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: {body: '/fo'}
+      }
+    })
+
     expect(callback).not.toHaveBeenCalled()
   })
 
-  it('invokes command on issue edit', () => {
-    const event = payload('hello world\n\n/foo bar')
-    robot.emit('issue_comment', event)
-    robot.emit('issue_comment.updated', event)
-    robot.emit('issue_comment.deleted', event)
+  it('invokes command on issue edit', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'updated',
+        comment: {body: '/foo bar'}
+      }
+    })
+
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'deleted',
+        comment: {body: '/foo bar'}
+      }
+    })
 
     expect(callback).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
I noticed in https://github.com/probot/probot.github.io/issues/196 that the command didn't work. I started looking into it, and it turns out this was reported in https://github.com/probot/reminders/issues/30.

This adds support for using commands in the original issue or pull request body.