### PR TITLE
Handle null issue/pr body

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ class Command {
   listener (context) {
     const { comment, issue, pull_request: pr } = context.payload
 
-    const command = (comment || issue || pr).body.match(this.matcher)
+    const body = (comment || issue || pr).body
+    if (!body) return
+
+    const command = body.match(this.matcher)
 
     if (command && this.name === command[1]) {
       return this.callback(context, { name: command[1], arguments: command[2] })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -118,4 +118,28 @@ describe('commands', () => {
     expect(callback).toHaveBeenCalled()
     expect(callback.mock.calls[0][1]).toEqual({ name: 'foo', arguments: 'bar' })
   })
+
+  it('ignores null pull_request.opened body', async () => {
+    await robot.receive({
+      event: 'pull_request',
+      payload: {
+        action: 'opened',
+        issue: { body: null }
+      }
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('ignores null issues.opened body', async () => {
+    await robot.receive({
+      event: 'issues',
+      payload: {
+        action: 'opened',
+        issue: { body: null }
+      }
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Resolves #9 

This PR checks to ensure that an issue, PR, or comment's `body` is truthy before attempting to find the command within the `body`.