### PR TITLE
Allow custom command format

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ class Command {
   }
 
   get matcher () {
-    return /^\/([\w]+)\b *(.*)?$/m
+    return this._matcher
   }
 
   listener (context) {
@@ -18,6 +18,8 @@ class Command {
     }
   }
 }
+
+Command.prototype._matcher = /^\/([\w]+)\b *(.*)?$/m
 
 /**
  * Probot extension to abstract pattern for receiving slash commands in comments.
@@ -37,3 +39,7 @@ module.exports = (robot, name, callback) => {
 }
 
 module.exports.Command = Command
+
+module.exports.setCommandFormat = (fmt) => {
+  Command.prototype._matcher = fmt
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,3 +119,101 @@ describe('commands', () => {
     expect(callback.mock.calls[0][1]).toEqual({ name: 'foo', arguments: 'bar' })
   })
 })
+
+describe('custom-format', () => {
+  let callback
+  let robot
+
+  beforeEach(() => {
+    callback = jest.fn()
+    robot = createRobot({ app: jest.fn().mockReturnValue('test') })
+    commands.setCommandFormat(/^@probot (\w+)\b *(.*)?$/m)
+    commands(robot, 'foo', callback)
+  })
+
+  it('invokes callback and passes command logic', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: 'hello world\n\n@probot foo bar' }
+      }
+    })
+
+    expect(callback).toHaveBeenCalled()
+    expect(callback.mock.calls[0][1]).toEqual({ name: 'foo', arguments: 'bar' })
+  })
+
+  it('invokes the command without arguments', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: 'hello world\n\n@probot foo' }
+      }
+    })
+
+    expect(callback).toHaveBeenCalled()
+    expect(callback.mock.calls[0][1]).toEqual({ name: 'foo', arguments: undefined })
+  })
+
+  it('does not call callback for other commands', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: 'hello world\n\n@probot nope no /foo see' }
+      }
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('does not call callback for superstring command matches', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@probot foobar' }
+      }
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('does not call callback for superstring wakeword matches', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@probots foobar' }
+      }
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('does not call callback for command substring matches', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@probot fo' }
+      }
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('does not call callback for wakeword substring matches', async () => {
+    await robot.receive({
+      event: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { body: '@pro foo' }
+      }
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This PR allows users to set a custom command format, for instance

> @probot do the thing

Aside from vanity, this would allow multiple bots to listen for the same command (but it's mostly for vanity).