### PR TITLE
Add ability to specify multiple slash commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,15 @@ class Command {
   listener (context) {
     const { comment, issue, pull_request: pr } = context.payload
 
-    const command = (comment || issue || pr).body.match(this.matcher)
+    const commands = (comment || issue || pr).body.split('\n').map(line => {
+      return line.match(this.matcher)
+    })
 
-    if (command && this.name === command[1]) {
-      return this.callback(context, { name: command[1], arguments: command[2] })
-    }
+    commands.forEach(command => {
+      if (command && this.name === command[1]) {
+        this.callback(context, { name: command[1], arguments: command[2] })
+      }
+    })
   }
 }
 


### PR DESCRIPTION
Adds ability to specify multiple slash commands per line. This is useful for things like:
```
/merge
/close
```
in order to merge a PR and close a ticket